### PR TITLE
Make version requirement match stumpy_png

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 dependencies:
   stumpy_core:
     git: https://github.com/stumpycr/stumpy_core.git
-    version: -> 1.7.0
+    version: ~> 1.7.0
 
 development_dependencies:
   minitest:


### PR DESCRIPTION
The version requirements are different, meaning Shards will throw an error when trying to use both `stumpy_png` and `stumpy_gif`