### PR TITLE
Add overload for using IO objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.crystal
 /.shards
 /libs
+/lib
 /tmp

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Interface
 
-* `StumpyGIF.write(frames : Array(Canvas), path, delay_between_frames = 10)`
+* `StumpyGIF.write(frames : Array(Canvas), path_or_io, delay_between_frames = 10)`
   saves a list of frames (canvasses) as a GIF image file,
   `delay_between_frames` is in 1/100 of a second
 * `Canvas` and `RGBA` from [stumpy_core](https://github.com/stumpycr/stumpy_core)

--- a/src/stumpy_gif.cr
+++ b/src/stumpy_gif.cr
@@ -11,43 +11,47 @@ require "./stumpy_gif/median_split"
 module StumpyGIF
   include StumpyCore
 
-  def self.write(frames, filename, delay_time = 10, quantization = :websafe)
+  def self.write(frames, filename : String, delay_time = 10, quantization = :websafe)
     File.open(filename, "w") do |io|
-      "GIF89a".chars.each do |char|
-        io.write_bytes(char.ord.to_u8, IO::ByteFormat::LittleEndian)
-      end
-
-      canvas = frames.first
-      lsd = LogicalScreenDescriptor.new(canvas.width, canvas.height)
-      lsd.write(io)
-
-      gct = ColorTable.new
-
-      case quantization
-      when :websafe
-        gct.colors = Websafe.colors
-      when :median_split
-        gct.colors = MedianSplit.colors(frames)
-      when :neuquant
-        gct.colors = NeuQuant.new(frames).colors
-      else
-        raise "Unknown quantization method: #{quantization}"
-      end
-
-      gct.write(io)
-
-      Extension::Netscape.new.write(io) if frames.size > 1
-
-
-      frames.each do |canvas|
-        gce = Extension::GraphicControl.new(delay_time)
-        gce.write(io)
-
-        image = Image.new(canvas, gct)
-        image.write(io)
-      end
-
-      io.write_bytes(0x3b_u8, IO::ByteFormat::LittleEndian)
+      write frames, io, delay_time, quantization
     end
+  end
+
+  def self.write(frames, io : IO, delay_time = 10, quantization = :websafe)
+    "GIF89a".chars.each do |char|
+      io.write_bytes(char.ord.to_u8, IO::ByteFormat::LittleEndian)
+    end
+
+    canvas = frames.first
+    lsd = LogicalScreenDescriptor.new(canvas.width, canvas.height)
+    lsd.write(io)
+
+    gct = ColorTable.new
+
+    case quantization
+    when :websafe
+      gct.colors = Websafe.colors
+    when :median_split
+      gct.colors = MedianSplit.colors(frames)
+    when :neuquant
+      gct.colors = NeuQuant.new(frames).colors
+    else
+      raise "Unknown quantization method: #{quantization}"
+    end
+
+    gct.write(io)
+
+    Extension::Netscape.new.write(io) if frames.size > 1
+
+
+    frames.each do |canvas|
+      gce = Extension::GraphicControl.new(delay_time)
+      gce.write(io)
+
+      image = Image.new(canvas, gct)
+      image.write(io)
+    end
+
+    io.write_bytes(0x3b_u8, IO::ByteFormat::LittleEndian)
   end
 end


### PR DESCRIPTION
Inspired by [stumpy_png#18](https://github.com/stumpycr/stumpy_png/pull/18)

Also adds `lib/` to `.gitignore` (`libs` [is no longer in CRYSTAL_PATH](https://github.com/crystal-lang/crystal/releases/tag/0.20.3) )